### PR TITLE
DAC6-3330: Update dependencies and plugins

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,14 +2,14 @@ import sbt._
 
 object AppDependencies {
 
-  private val bootstrapVersion = "9.1.0"
+  private val bootstrapVersion = "9.5.0"
   private val hmrcMongoVersion = "2.2.0"
 
   val compile = Seq[ModuleID](
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"    % "10.1.0",
-    "uk.gov.hmrc"       %% "crypto-json-play-30"           % "8.0.0",
-    "uk.gov.hmrc"       %% "play-conditional-form-mapping-play-30" % "2.0.0",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"    % "10.13.0",
+    "uk.gov.hmrc"       %% "crypto-json-play-30"           % "8.1.0",
+    "uk.gov.hmrc"       %% "play-conditional-form-mapping-play-30" % "3.2.0",
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-30"    % bootstrapVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"            % hmrcMongoVersion
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.22.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.5.0")
 
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.4")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.5")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.9")
 


### PR DESCRIPTION
Upgraded various dependencies for better performance and security, including bootstrap to 9.5.0, play-frontend-hmrc-play-30 to 10.13.0, crypto-json-play-30 to 8.1.0, and play-conditional-form-mapping-play-30 to 3.2.0. Also updated sbt-plugin from Play framework to version 3.0.5 in plugins.sbt.