### PR TITLE
DAC6-3648: Refactor connectors to use HttpClientV2

### DIFF
--- a/app/connectors/EnrolmentStoreProxyConnector.scala
+++ b/app/connectors/EnrolmentStoreProxyConnector.scala
@@ -22,12 +22,13 @@ import play.api.Logging
 import play.api.http.Status.NO_CONTENT
 import uk.gov.hmrc.http.HttpReads.Implicits.readRaw
 import uk.gov.hmrc.http.HttpErrorFunctions.is2xx
-import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
-class EnrolmentStoreProxyConnector @Inject() (val config: FrontendAppConfig, val http: HttpClient) extends Logging {
+class EnrolmentStoreProxyConnector @Inject() (val config: FrontendAppConfig, val http: HttpClientV2) extends Logging {
 
   def enrolmentExists(subscriptionInfo: SubscriptionInfo)(implicit
     hc: HeaderCarrier,
@@ -41,12 +42,11 @@ class EnrolmentStoreProxyConnector @Inject() (val config: FrontendAppConfig, val
       }
       .getOrElse(s"HMRC-CBC-NONUK-ORG~cbcId~${subscriptionInfo.cbcId}")
 
-    val submissionUrl = s"${config.enrolmentStoreProxyUrl}/enrolment-store/enrolments/$serviceEnrolmentPattern/groups"
+    val submissionUrl = url"${config.enrolmentStoreProxyUrl}/enrolment-store/enrolments/$serviceEnrolmentPattern/groups"
 
     http
-      .GET[HttpResponse](
-        submissionUrl
-      )(rds = readRaw, hc = hc, ec = ec)
+      .get(submissionUrl)
+      .execute[HttpResponse]
       .map {
         case response if response.status == NO_CONTENT => false
         case response if is2xx(response.status) =>

--- a/app/connectors/SubscriptionConnector.scala
+++ b/app/connectors/SubscriptionConnector.scala
@@ -21,21 +21,24 @@ import models.subscription.request.CreateSubscriptionForCBCRequest
 import models.subscription.response.{CreateSubscriptionResponse, DisplaySubscriptionResponse}
 import models.{SafeId, SubscriptionID}
 import play.api.Logging
+import play.api.libs.json.Json
 import uk.gov.hmrc.http.HttpReads.Implicits.readRaw
 import uk.gov.hmrc.http.HttpErrorFunctions.is2xx
-import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
-class SubscriptionConnector @Inject() (val config: FrontendAppConfig, val http: HttpClient) extends Logging {
+class SubscriptionConnector @Inject() (val config: FrontendAppConfig, val http: HttpClientV2) extends Logging {
 
   def readSubscription(safeId: SafeId)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[SubscriptionID]] = {
 
-    val submissionUrl = s"${config.registerCountryByCountryUrl}/subscription/read-subscription/${safeId.value}"
+    val submissionUrl = url"${config.registerCountryByCountryUrl}/subscription/read-subscription/${safeId.value}"
 
     http
-      .POSTEmpty(submissionUrl)
+      .post(submissionUrl)
+      .execute[HttpResponse]
       .map {
         case responseMessage if is2xx(responseMessage.status) =>
           responseMessage.json
@@ -56,12 +59,11 @@ class SubscriptionConnector @Inject() (val config: FrontendAppConfig, val http: 
     createSubscriptionForCBCRequest: CreateSubscriptionForCBCRequest
   )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[SubscriptionID]] = {
 
-    val submissionUrl = s"${config.registerCountryByCountryUrl}/subscription/create-subscription"
+    val submissionUrl = url"${config.registerCountryByCountryUrl}/subscription/create-subscription"
     http
-      .POST[CreateSubscriptionForCBCRequest, HttpResponse](
-        submissionUrl,
-        createSubscriptionForCBCRequest
-      )
+      .post(submissionUrl)
+      .withBody(Json.toJson(createSubscriptionForCBCRequest))
+      .execute[HttpResponse]
       .map {
         case response if is2xx(response.status) =>
           response.json.asOpt[CreateSubscriptionResponse].map(_.subscriptionID)

--- a/app/models/register/request/RegisterWithoutId.scala
+++ b/app/models/register/request/RegisterWithoutId.scala
@@ -93,6 +93,10 @@ object RequestCommon {
   }
 }
 
+/** Missing Fields:
+  * isAGroup: Boolean
+  * isAnAgent: Boolean
+  */
 case class RequestDetails(
   organisation: NoIdOrganisation,
   address: Address,

--- a/app/models/register/request/RegisterWithoutId.scala
+++ b/app/models/register/request/RegisterWithoutId.scala
@@ -93,10 +93,6 @@ object RequestCommon {
   }
 }
 
-/** Missing Fields:
-  * isAGroup: Boolean
-  * isAnAgent: Boolean
-  */
 case class RequestDetails(
   organisation: NoIdOrganisation,
   address: Address,

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -22,7 +22,6 @@ play.filters.enabled += play.filters.csp.CSPFilter
 play.filters.enabled += "uk.gov.hmrc.play.bootstrap.frontend.filters.SessionIdFilter"
 play.http.errorHandler = "handlers.ErrorHandler"
 
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientV2Module"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
 play.modules.enabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"


### PR DESCRIPTION
Replaced deprecated HttpClient with HttpClientV2 across all connectors for improved HTTP handling. Updated related method calls to align with the new client API and ensured compatibility with configuration changes.